### PR TITLE
Added option "data-graph-xaxis-labels-font-size".

### DIFF
--- a/jquery.highchartTable.js
+++ b/jquery.highchartTable.js
@@ -347,7 +347,10 @@
           {
             rotation: $table.data('graph-xaxis-rotation') || 0,
             align:    $table.data('graph-xaxis-align') || 'center', 
-            enabled:  typeof xAxisLabelsEnabled != 'undefined' ? xAxisLabelsEnabled : true 
+            enabled:  typeof xAxisLabelsEnabled != 'undefined' ? xAxisLabelsEnabled : true,
+            style:    {
+              fontSize: $table.data('graph-xaxis-labels-font-size') || '100%'
+            }
           },
           startOnTick: $table.data('graph-xaxis-start-on-tick'),
           endOnTick:   $table.data('graph-xaxis-end-on-tick'),


### PR DESCRIPTION
=> Allows one to specify the font-size that is to be used for labels on the X-axis.
(Useful if you have labels that are too long, and, hence, take too much space on your graph)
