### PR TITLE
Some more options to use spiderweb graph and polar chart

### DIFF
--- a/jquery.highchartTable.js
+++ b/jquery.highchartTable.js
@@ -346,7 +346,7 @@
           spacingTop:   $table.data('graph-spacing-top') || 10,
           height:       $table.data('graph-height') || null,
           zoomType:     $table.data('graph-zoom-type') || null,
-          polar:        $table.data('graph-polar') ? $table.data('graph-polar') : undefined
+          polar:        $table.data('graph-polar') || null
         },
         title: {
           text: graphTitle
@@ -394,7 +394,7 @@
           },
           gridLineWidth:     $table.data('graph-xaxis-gridLine-width') || 0,
           gridLineDashStyle: $table.data('graph-xaxis-gridLine-style') || 'ShortDot',
-          tickmarkPlacement: 'on',
+          tickmarkPlacement: $table.data('graph-xaxis-tickmark-placement') || 'between',
           lineWidth:         $table.data('graph-xaxis-line-width') || 0
         },
         yAxis: yAxisConfig,


### PR DESCRIPTION
Need to include highcharts-more.js
- data-graph-polar
  "true" to render a polar graph.
  Default: null
  - data-graph-yaxis-{X}-grid-line-interpolation
    Define the graph type.
    Default: null
    ex: "polygon" to get a spiderweb graph
  - data-graph-xaxis-show-last-label
    If you have a number on the last label, put it to false.
    Default: true
  - tickmarkPlacement
    For categorized axes only. If "on" the tick mark is placed in the center of the category, if "between" the tick mark is placed between categories.
    default: "between"
  - data-graph-xaxis-gridLine-width
    The width of the grid lines extending the ticks across the plot area.
    Default: 0
