### PR TITLE
added option to display legend for pie charts

### DIFF
--- a/jquery.highchartTable.js
+++ b/jquery.highchartTable.js
@@ -413,7 +413,7 @@
             dataLabels: {
               enabled: true
             },
-            showInLegend: 0,
+            showInLegend: $table.data('graph-pie-show-in-legend') == '1',
             size:         '80%'
           },
           series: {


### PR DESCRIPTION
By default pie charts legend are disabled and it was not possible
to activate them (only via datalabels but not with "normal" legends.

Now the data-graph-pie-show-in-legend allows to enable legend for pie
charts.

See issue #42
