### PR TITLE
remove default value for the data-graph-yaxis-X-title-text attribute

### DIFF
--- a/jquery.highchartTable.js
+++ b/jquery.highchartTable.js
@@ -259,7 +259,7 @@
       for (yAxisNum=1 ; yAxisNum <= nbYaxis ; yAxisNum++) {
         var yAxisConfigCurrentAxis = {
           title: {
-            text: typeof $table.data('graph-yaxis-'+yAxisNum+'-title-text') != 'undefined'  ? $table.data('graph-yaxis-'+yAxisNum+'-title-text') : "Valeur"
+            text: typeof $table.data('graph-yaxis-'+yAxisNum+'-title-text') != 'undefined'  ? $table.data('graph-yaxis-'+yAxisNum+'-title-text') : null
           },
           max:          typeof $table.data('graph-yaxis-'+yAxisNum+'-max') != 'undefined' ? $table.data('graph-yaxis-'+yAxisNum+'-max') : null,
           min:          typeof $table.data('graph-yaxis-'+yAxisNum+'-min') != 'undefined' ? $table.data('graph-yaxis-'+yAxisNum+'-min') : null,


### PR DESCRIPTION
The default value for the data-graph-yaxis-X-title-text attribute is "Valeur".

It should'nt be a french value. We can remove the default value (see #8).

People using the default value can do something like this for backward compatibility : 

``` js
$('table.highchart').bind('highchartTable.beforeRender', function(event, highChartConfig) {
  $.each(highChartConfig.yAxis, function (index, value)   {
    value.title.text = value.title.text || 'Valeur';
  });
});
```
