### PR TITLE
Remove all blank characters

### DIFF
--- a/jquery.highchartTable.js
+++ b/jquery.highchartTable.js
@@ -221,7 +221,7 @@
                 serie.data.push(null);
               }
             } else {
-              var cleanedCellValue = rawCellValue.replace(/ /g, '').replace(/,/, '.');
+              var cleanedCellValue = rawCellValue.replace(/\s/g, '').replace(/,/, '.');
               cellValue = Math.round(parseFloat(cleanedCellValue) * column.scale * 100) / 100;
 
                 var dataGraphX = $td.data('graph-x');


### PR DESCRIPTION
Remove every blank characters instead of only removing the space characters.

There was a bug when rendering un number with the IntlNumberFormatter in PHP
