### PR TITLE
xaxis label autorotation fix

### DIFF
--- a/jquery.highchartTable.js
+++ b/jquery.highchartTable.js
@@ -381,8 +381,8 @@
           },
           labels:
           {
-            rotation: $table.data('graph-xaxis-rotation') || 0,
-            align:    $table.data('graph-xaxis-align') || 'center', 
+            rotation: $table.data('graph-xaxis-rotation') || undefined,
+            align:    $table.data('graph-xaxis-align') || undefined, 
             enabled:  typeof xAxisLabelsEnabled != 'undefined' ? xAxisLabelsEnabled : true,
             style:    xAxisLabelStyle
           },


### PR DESCRIPTION
Use undefined rather than 0 or center.
This will honor the highchart's default configuration/fallback mechanisms.

See difference: http://i.imgur.com/UmDVO6X.png