### PR TITLE
add event to customize cleaning of cell values

### DIFF
--- a/jquery.highchartTable.js
+++ b/jquery.highchartTable.js
@@ -222,7 +222,16 @@
               }
             } else {
               var cleanedCellValue = rawCellValue.replace(/\s/g, '').replace(/,/, '.');
-              cellValue = Math.round(parseFloat(cleanedCellValue) * column.scale * 100) / 100;
+              var eventOptions = {
+                 value: cleanedCellValue,
+                 rawValue: rawCellValue,
+                 td: $td,
+                 tr: $(row),
+                 indexTd: indexTd,
+                 indexTr: indexRow
+               }
+               $table.trigger('highchartTable.cleanValue', eventOptions);
+               cellValue = Math.round(parseFloat(eventOptions.value) * column.scale * 100) / 100;
 
                 var dataGraphX = $td.data('graph-x');
 


### PR DESCRIPTION
Exemple of usage :
```
        $('table.highchart')
          .on('highchartTable.cleanValue', function(value, options) {
               if (options.indexTr == 0) {
                 options.value = options.value.replace(/\$/, '');
               }
          })
	  .highchartTable()
```

List of options passed to the event :
* value (that's the one that must be changed, contains the value already cleaned by HighchartTable)
* rawValue : the value not cleaned by HighchartTable
* td : jQuery objet of the td were the valued is extracted from
* tr : jQuery objet of the tr where is td is readed from
* indexTr : index of the tr (starts at 0)
* indexTd : index of the td (starts at 1)

see #59 